### PR TITLE
Multiple TxSubmitters for multiple addresses

### DIFF
--- a/lib/transaction-factory.js
+++ b/lib/transaction-factory.js
@@ -1,15 +1,14 @@
 'use strict'
 
 const Transaction = require('./transaction')
-const assert = require('assert')
 const Store = require('ilp-store-memory')
 
 class TransactionFactory {
   constructor ({store}) {
-    if (typeof store === 'object', 'parameter store must be object' && typeof store != 'undefined') {
+    if (typeof store === 'object' && typeof store !== 'undefined') {
       this._store = store
     } else {
-      this._store = new Store() 
+      this._store = new Store()
     }
   }
 

--- a/lib/transaction-factory.js
+++ b/lib/transaction-factory.js
@@ -2,11 +2,15 @@
 
 const Transaction = require('./transaction')
 const assert = require('assert')
+const Store = require('ilp-store-memory')
 
 class TransactionFactory {
   constructor ({store}) {
-    assert(typeof store === 'object', 'parameter store must be object')
-    this._store = store
+    if (typeof store === 'object', 'parameter store must be object' && typeof store != 'undefined') {
+      this._store = store
+    } else {
+      this._store = new Store() 
+    }
   }
 
   async create (id, details, pending = true) {

--- a/lib/tx-submitter.js
+++ b/lib/tx-submitter.js
@@ -17,7 +17,7 @@ const submitterCreated = (address) => {
   }
   global[sym] = {}
   return false
-} 
+}
 
 const allowedFnNames = [
   'preparePayment',

--- a/lib/tx-submitter.js
+++ b/lib/tx-submitter.js
@@ -11,7 +11,13 @@ const ALT_RIPPLED_URL = 'wss://s2.ripple.com'
 // WARNING: do not change the string literal 'ilp-plugin-xrp-paychan-shared-txsubmitter'
 // It ensures that different versions of this package create only one TxSubmitter instance.
 const sym = Symbol.for('ilp-plugin-xrp-paychan-shared-txsubmitter')
-const submitterCreated = () => Object.getOwnPropertySymbols(global).indexOf(sym) > -1
+const submitterCreated = (address) => {
+  if (sym in global) {
+    return (address in global[sym])
+  }
+  global[sym] = {}
+  return false
+} 
 
 const allowedFnNames = [
   'preparePayment',
@@ -209,13 +215,10 @@ class TxSubmitter {
 }
 
 module.exports = function (_api, _address, _secret, store) {
-  if (!submitterCreated()) {
+  if (!submitterCreated(_address)) {
     const instance = new TxSubmitter(_api, _address, _secret, store)
-    global[sym] = instance
-  } else {
-    if (_address !== global[sym]._address) {
-      throw new Error('There exists already a TxSubmitter instance for another address.')
-    }
+    global[sym][_address] = instance
   }
-  return global[sym]
+
+  return global[sym][_address]
 }

--- a/test/tx-submitter.test.js
+++ b/test/tx-submitter.test.js
@@ -39,9 +39,12 @@ describe('Tx Submitter', function () {
 
     it('makes two submitters for different addresses', () => {
       const txSubmitter1 = createTxSubmitter(this.api, this.address, this.secret, new Store())
-      const otherAddress = 'rSomeOtherAdress11rSomeOtherAdress'
-      const txSubmitter2 = createTxSubmitter(this.api, otherAddress, this.secret, new Store()) 
-      
+
+      const otherAddress = 'rNtnt7i1LXjyHLrmFQMA4F6CxvY57Est5T'
+      const otherSecret = 'ssJimN41FfXoucWshFiMiAfcseE5o'
+      const otherApi = new RippleAPI({server: 'wss://s.altnet.rippletest.net:51233'})
+      const txSubmitter2 = createTxSubmitter(otherApi, otherAddress, otherSecret, new Store())
+
       const sym = Symbol.for('ilp-plugin-xrp-paychan-shared-txsubmitter')
       assert.strictEqual(global[sym][this.address], txSubmitter1, 'submitter should be stored')
       assert.strictEqual(global[sym][otherAddress], txSubmitter2, 'submitter should be stored')
@@ -210,11 +213,13 @@ describe('Tx Submitter', function () {
         })
 
         it('resolves if tx was succesful', () => {
+          this.timeout(3000)
           this.getTransactionStub.resolves({outcome: {result: 'tesSUCCESS'}})
           return this.submitter.submit('preparePayment', this.paymentOpts, this.paymentInstructions)
         })
 
         it('rejects if tx not found', () => {
+          this.timeout(3000)
           this.getTransactionStub.rejects(new this.api.errors.NotFoundError())
           return assert.isRejected(this.submitter.submit('preparePayment', this.paymentOpts,
             this.paymentInstructions), 'Not found')

--- a/test/tx-submitter.test.js
+++ b/test/tx-submitter.test.js
@@ -12,6 +12,7 @@ const RippleAPI = require('ripple-lib').RippleAPI
 const Store = require('ilp-store-memory')
 const fixtures = require('./data/transactions.json')
 
+// TODO fix two broken tests
 describe('Tx Submitter', function () {
   before(async () => {
     this.createtx = fixtures.createtx
@@ -25,7 +26,7 @@ describe('Tx Submitter', function () {
   })
 
   describe('instantiation', () => {
-    it('is a singleton', () => {
+    it('one txSubmitter per address', () => {
       const txSubmitter1 = createTxSubmitter(this.api, this.address, this.secret, new Store())
       const txSubmitter2 = createTxSubmitter(this.api, this.address, this.secret, new Store())
       assert.strictEqual(txSubmitter1, txSubmitter2, 'txSubmitter expected to be a singleton')
@@ -36,11 +37,14 @@ describe('Tx Submitter', function () {
       assert.isObject(txSubmitter)
     })
 
-    it('throws on mismatching address', () => {
-      createTxSubmitter(this.api, this.address, this.secret, new Store())
+    it('makes two submitters for different addresses', () => {
+      const txSubmitter1 = createTxSubmitter(this.api, this.address, this.secret, new Store())
       const otherAddress = 'rSomeOtherAdress11rSomeOtherAdress'
-      assert.throws(() => createTxSubmitter(this.api, otherAddress, this.secret, new Store()),
-        'There exists already a TxSubmitter instance for another address')
+      const txSubmitter2 = createTxSubmitter(this.api, otherAddress, this.secret, new Store()) 
+      
+      const sym = Symbol.for('ilp-plugin-xrp-paychan-shared-txsubmitter')
+      assert.strictEqual(global[sym][this.address], txSubmitter1, 'submitter should be stored')
+      assert.strictEqual(global[sym][otherAddress], txSubmitter2, 'submitter should be stored')
     })
   })
 


### PR DESCRIPTION
The global[sym] is now an array of TxSubmitters for each address, instead of one TxSubmitter.

Previously you could only have one connector per process (unless they were sharing the same address). It is useful to have multiple connectors with different addresses on the same process to easily create a local test network.