### PR TITLE
normalize _verifyTx response

### DIFF
--- a/lib/tx-submitter.js
+++ b/lib/tx-submitter.js
@@ -127,7 +127,14 @@ class TxSubmitter {
       const txData = await api.getTransaction(txId, txOpts)
       if (txData.outcome.result === 'tesSUCCESS') {
         debug(`tx ${txId} was included in a validated ledger`)
-        resolve(txData)
+        const transaction = {
+          Account: txData.address,
+          Destination: txData.specification.destination,
+          Fee: txData.outcome.fee,
+          Sequence: txData.sequence,
+          hash: txData.id
+        };
+        resolve({...txData, transaction})
       } else {
         debug(`tx ${txId} failed. details=${txData}`)
         reject(new Error('transaction submission failed'))


### PR DESCRIPTION
_verifyTx(_addLedgerClosedHandler) will resolve with completely different schema compare to `_addTransactionHandler` as it use `getTransaction` method from `ripple-lib` so the return value is something as below and described in this [link](https://github.com/ripple/ripple-lib/blob/develop/docs/index.md#example-25):

<details>
  <summary>Response schema</summary>
  
```
{ type: 'paymentChannelCreate',
  address: 'raCvb2P8BPjGcQMvWmmsMMJjpe6BF4A3YB',
  sequence: 145,
  id: 'BCE15851F0B19E37B50346912BE06D3172F6EF436C85A0C37E5ED0668A96EA8B',
  specification: 
   { amount: '1',
     destination: 'rDdEAmwEtWjy1d8sGMxXERKgT1Trz9581e',
     settleDelay: 3600,
     publicKey: 'ED743C9F0272A0E0C885DF42F9647C0337A287837163F888EDF1D62C4723AC7572',
     sourceTag: 4251316999 },
  outcome: 
   { result: 'tesSUCCESS',
     timestamp: '2019-05-16T19:29:12.000Z',
     fee: '0.000012',
     balanceChanges: { raCvb2P8BPjGcQMvWmmsMMJjpe6BF4A3YB: [Array] },
     orderbookChanges: {},
     ledgerVersion: 19441543,
     indexInLedger: 2 } 
}

```
</details>

it will raise key error in [ilp-plugin-xrp-paychan#L419](
https://github.com/interledgerjs/ilp-plugin-xrp-paychan/blob/d0f9137551aaf3c81f17c3c2544b980416d06b30/index.js#L419) and [ilp-plugin-xrp-asym-server#L383](https://github.com/interledgerjs/ilp-plugin-xrp-asym-server/blob/cc92e500489a50c73d9bd619dc92b5abe95085b6/src/index.ts#L383) as there is no `transaction` key in the response.

I faced with this issues as on testnet after a while the subscription on `transactions streams` will stop working and ledger close event would handle the tx submissions callback. 

maybe it would be good to add an `timeout` for the `on transaction` event so if after a while there would be no transaction event, then we can restart the connection/resubscribe.

if the code needs any change please let me know :+1: 





